### PR TITLE
add explanation to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,4 +4,6 @@ Testing pull request behavior
 Sometimes the GitHub UI and REST API do not always show a PR's commits in the
 order that Git itself uses.
 
-https://help.github.com/articles/why-are-my-commits-in-the-wrong-order/
+See GitHub's site `Why are my commits in the wrong order?`_
+
+.. _Why are my commits in the wrong order?: https://help.github.com/articles/why-are-my-commits-in-the-wrong-order/

--- a/README.rst
+++ b/README.rst
@@ -3,3 +3,5 @@ Testing pull request behavior
 
 Sometimes the GitHub UI and REST API do not always show a PR's commits in the
 order that Git itself uses.
+
+https://help.github.com/articles/why-are-my-commits-in-the-wrong-order/

--- a/README.rst
+++ b/README.rst
@@ -1,2 +1,5 @@
 Testing pull request behavior
 =============================
+
+Sometimes the GitHub UI and REST API do not always show a PR's commits in the
+order that Git itself uses.


### PR DESCRIPTION
The original order of commits in this PR:

1. README: add link to GitHub's site
2. README: textualize link
3. README: add a paragraph explaining this repo